### PR TITLE
Fix instructions for ln command for Mac users

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -19,6 +19,10 @@ $ mkdir roles
 $ for ROLE in govready openscap scap-security-guide; do
     ln -frs ../../openprivacy.${ROLE} roles
 done
+# OS X does not require `-r` flag to create symbolic links, so Mac users do this intead
+$ for ROLE in govready openscap scap-security-guide; do
+    ln -fs ../../openprivacy.${ROLE} roles
+done
 ```
 
 You may want to change the base box into one that you like. The current one is based on geerlingguy's [CentOS 7 box](https://atlas.hashicorp.com/geerlingguy/boxes/centos7).


### PR DESCRIPTION
`ln -frs` command fails on OS X because `ln` does not have `-r` command for relative. Links are made relative on OS X bash when specified with relative paths.
